### PR TITLE
[FIX] theme_*: fix breadcrumb color

### DIFF
--- a/theme_anelusia/static/src/scss/bootstrap_overridden.scss
+++ b/theme_anelusia/static/src/scss/bootstrap_overridden.scss
@@ -45,13 +45,3 @@ $dropdown-box-shadow:                       0 .375rem 1.75em rgba(o-color('black
 $badge-padding-y:                           .3125rem !default;
 $badge-padding-x:                           .625rem !default;
 $badge-border-radius:                       .625rem !default;
-
-// Breadcrumbs
-
-$breadcrumb-padding-y:                      .5rem !default;
-$breadcrumb-padding-x:                      .9375rem !default;
-
-$breadcrumb-margin-bottom:                  1.25rem !default;
-
-$breadcrumb-bg:                             o-color('white') !default;
-$breadcrumb-active-color:                   o-color('600') !default;

--- a/theme_clean/static/src/scss/bootstrap_overridden.scss
+++ b/theme_clean/static/src/scss/bootstrap_overridden.scss
@@ -5,7 +5,3 @@
 $box-shadow-sm:               0 0 .3125rem rgba(0,0,0,.25) !default;
 $box-shadow:                  0 0 .3125rem rgba(0,0,0,.25) !default;
 $box-shadow-lg:               0 0 .3125rem rgba(0,0,0,.25) !default;
-
-// Breadcrumbs
-
-$breadcrumb-bg:                     o-color('white') !default;

--- a/theme_enark/static/src/scss/bootstrap_overridden.scss
+++ b/theme_enark/static/src/scss/bootstrap_overridden.scss
@@ -5,7 +5,3 @@
 $box-shadow-sm:               0 0 .3125rem rgba(0,0,0,.25) !default;
 $box-shadow:                  0 0 .3125rem rgba(0,0,0,.25) !default;
 $box-shadow-lg:               0 0 .3125rem rgba(0,0,0,.25) !default;
-
-// Breadcrumbs
-
-$breadcrumb-bg:                     o-color('white') !default;

--- a/theme_kea/static/src/scss/bootstrap_overridden.scss
+++ b/theme_kea/static/src/scss/bootstrap_overridden.scss
@@ -7,7 +7,3 @@ $headings-font-weight:     500 !default;
 $box-shadow-sm:               0 0 .3125rem rgba(0,0,0,.25) !default;
 $box-shadow:                  0 0 .3125rem rgba(0,0,0,.25) !default;
 $box-shadow-lg:               0 0 .3125rem rgba(0,0,0,.25) !default;
-
-// Breadcrumbs
-
-$breadcrumb-bg:                     o-color('white') !default;

--- a/theme_kiddo/static/src/scss/bootstrap_overridden.scss
+++ b/theme_kiddo/static/src/scss/bootstrap_overridden.scss
@@ -3,7 +3,3 @@
 $box-shadow-sm:               0 0 .3125rem rgba(0,0,0,.25) !default;
 $box-shadow:                  0 0 .3125rem rgba(0,0,0,.25) !default;
 $box-shadow-lg:               0 0 .3125rem rgba(0,0,0,.25) !default;
-
-// Breadcrumbs
-
-$breadcrumb-bg:                     o-color('white') !default;

--- a/theme_loftspace/static/src/scss/bootstrap_overridden.scss
+++ b/theme_loftspace/static/src/scss/bootstrap_overridden.scss
@@ -3,7 +3,3 @@
 $box-shadow-sm:               0 0 .3125rem rgba(0,0,0,.25) !default;
 $box-shadow:                  0 0 .3125rem rgba(0,0,0,.25) !default;
 $box-shadow-lg:               0 0 .3125rem rgba(0,0,0,.25) !default;
-
-// Breadcrumbs
-
-$breadcrumb-bg:                     o-color('white') !default;

--- a/theme_notes/static/src/scss/bootstrap_overridden.scss
+++ b/theme_notes/static/src/scss/bootstrap_overridden.scss
@@ -4,10 +4,6 @@ $box-shadow-sm:               0 0 .3125rem rgba(0,0,0,.25) !default;
 $box-shadow:                  0 0 .3125rem rgba(0,0,0,.25) !default;
 $box-shadow-lg:               0 0 .3125rem rgba(0,0,0,.25) !default;
 
-// Breadcrumbs
-
-$breadcrumb-bg:                     o-color('white') !default;
-
 // Headings font weight
 
 $headings-font-weight: $o-theme-headings-font-weight !default;


### PR DESCRIPTION
*: anelusia, anelusia, enark, kiddo, loftspace, notes

- Install Website e-commerce.
- Select the "Kea" theme for your website.
- Go to the "/shop" page.
- Click on "Desks" category to go to the "/shop/category/desks-1" page.
- Click on edit to enter edit mode.
- Click on the "theme" tab.
- Change the website background color to "black".
- Bug: The breadcrumb has an ugly white background instead of no background color, as in the "default" theme. Also, the "active" breadcrumb item is hidden due to white text on a white background.

This commit removes the white background from the breadcrumb for all themes that use it. This ensures the same appearance as other themes.

opw-4232082

closes odoo/design-themes#1013